### PR TITLE
feat: replace with VectorDB QA chain package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,9 +1,116 @@
-.venv
-.idea
-.pytest_cache
-*.pyc
-build
-src/keys.py
 src/.steamship/secrets.toml
 .steamship/secrets.toml
+
+# Coverage.py
+htmlcov/
+reports/
+
+# cruft
+*.rej
+
+# Data
+*.dat*
+*.pickle*
+*.pkl*
+*.xls*
+*.xlsxZ*
+*.zip*
+
+# direnv
+.envrc
+
+
+# Distribution / packaging
+*.egg-info/
+
+
+# dotenv
+.env
+
+# Hypothesis
+.hypothesis/
+
+# Jupyter
+.ipynb_checkpoints/
+notebooks/
+
+# macOS
 .DS_Store
+
+# mypy
+.dmypy.json
+.mypy_cache/
+
+# Node.js
+node_modules/
+
+# Poetry
+.venv/
+dist/
+
+# PyCharm
+.idea/
+
+# pyenv
+.python-version
+
+# pytest
+.pytest_cache/
+*reports/pytest.xml
+
+# Python
+__pycache__/
+*.py[cdo]
+
+# Terraform
+.terraform/
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+.fleet/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# SonarLint plugin
+.idea/sonarlint/
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+# VS Code
+.vscode/
+
+# Tox
+.tox/
+
+# Coverage
+.coverage/
+
+# Generated website
+docs/_build
+
+# Steamship packaging directories
+build/

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,4 @@
-pytest==7.0.0
+pytest==7.2.0
 pre-commit==2.19.0
 pycln==1.3.2
 isort==5.10.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
-steamship===2.2.0
+steamship-langchain
+steamship
+langchain

--- a/steamship.json
+++ b/steamship.json
@@ -1,23 +1,42 @@
 {
-  "type": "package",
-  "handle": "question-answering",
-  "version": "1.0.0",
-  "description": "Record text and match questions to it later.",
-  "author": "Steamship",
-  "entrypoint": "src.api.handler",
-  "steamshipRegistry": {
-    "tagline": "Record text and and match them to questions later.",
-    "tagline2": "Just add facts as plain text. Answers are always the facts exactly as you've provided them.",
-    "usefulFor": "Useful for developers building natural language lookup into FAQs and other lists.",
-    "videoUrl": null,
-    "githubUrl": "https://github.com/steamship-packages/question-answering/",
-    "demoUrl": null,
-    "blogUrl": null,
-    "jupyterUrl": null,
-    "authorName": "Steamship",
-    "authorEmail": "hello@steamship.com",
-    "authorTwitter": "@GetSteamship",
-    "authorUrl": "https://www.steamship.com/",
-    "tags": ["Embeddings", "Question Answering", "Chatbots", "Search", "NLU"]
-  }
+	"type": "package",
+	"handle": "question-answering",
+	"version": "0.0.7",
+	"description": "",
+	"author": "steamship",
+	"entrypoint": "Unused",
+	"public": true,
+	"plugin": null,
+	"build_config": {
+		"ignore": [
+			"tests",
+			"examples"
+		]
+	},
+	"configTemplate": {
+		"index_name": {
+			"type": "string",
+			"description": null,
+			"default": null
+		}
+	},
+	"steamshipRegistry": {
+		"tagline": "Answers questions based on a populated index",
+		"tagline2": null,
+		"usefulFor": null,
+		"videoUrl": null,
+		"githubUrl": null,
+		"demoUrl": null,
+		"blogUrl": null,
+		"jupyterUrl": null,
+		"authorGithub": "",
+		"authorName": "steamship",
+		"authorEmail": null,
+		"authorTwitter": null,
+		"authorUrl": null,
+		"tags": [
+			"Question Answering",
+			"Embeddings"
+		]
+	}
 }


### PR DESCRIPTION
Update to a more 'modern' Steamship package, and use a chain to do answering, based on an index populated elsewhere (we can add an `index` or `add_sources` method if we want in a follow-up).